### PR TITLE
fix: support folders with spaces in npm

### DIFF
--- a/src/executable/DprintExecutable.ts
+++ b/src/executable/DprintExecutable.ts
@@ -54,7 +54,7 @@ export class DprintExecutable {
   }
 
   get cmdPath() {
-    return `"${this.#cmdPath}"`;
+    return this.#cmdPath;
   }
 
   get initializationFolderUri() {
@@ -66,7 +66,7 @@ export class DprintExecutable {
 
   async checkInstalled() {
     try {
-      await this.#execShell([this.cmdPath, "-v"], undefined, undefined);
+      await this.#execShell([this.#cmdPath, "-v"], undefined, undefined);
       return true;
     } catch (err: any) {
       this.#logger.logError(err.toString());
@@ -76,7 +76,7 @@ export class DprintExecutable {
 
   async getEditorInfo() {
     const stdout = await this.#execShell(
-      [this.cmdPath, "editor-info", ...this.#getConfigArgs()],
+      [this.#cmdPath, "editor-info", ...this.#getConfigArgs()],
       undefined,
       undefined,
     );
@@ -107,7 +107,7 @@ export class DprintExecutable {
       args.push("--verbose");
     }
 
-    return spawn(this.cmdPath, args, {
+    return spawn(`"${this.#cmdPath}"`, args, {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: this.#cwd.fsPath,
       // Set to true, to ensure this resolves properly on windows.
@@ -124,7 +124,7 @@ export class DprintExecutable {
     return new Promise<string>((resolve, reject) => {
       let cancellationDisposable: vscode.Disposable | undefined;
       try {
-        const process = exec(command.join(" "), {
+        const process = exec(command.map(c => `"${c}"`).join(" "), {
           cwd: this.#cwd.fsPath,
           encoding: "utf8",
         }, (err, stdout, stderr) => {

--- a/src/executable/DprintExecutable.ts
+++ b/src/executable/DprintExecutable.ts
@@ -54,7 +54,7 @@ export class DprintExecutable {
   }
 
   get cmdPath() {
-    return this.#cmdPath;
+    return `"${this.#cmdPath}"`;
   }
 
   get initializationFolderUri() {
@@ -66,7 +66,7 @@ export class DprintExecutable {
 
   async checkInstalled() {
     try {
-      await this.#execShell([this.#cmdPath, "-v"], undefined, undefined);
+      await this.#execShell([this.cmdPath, "-v"], undefined, undefined);
       return true;
     } catch (err: any) {
       this.#logger.logError(err.toString());
@@ -76,7 +76,7 @@ export class DprintExecutable {
 
   async getEditorInfo() {
     const stdout = await this.#execShell(
-      [this.#cmdPath, "editor-info", ...this.#getConfigArgs()],
+      [this.cmdPath, "editor-info", ...this.#getConfigArgs()],
       undefined,
       undefined,
     );
@@ -107,7 +107,7 @@ export class DprintExecutable {
       args.push("--verbose");
     }
 
-    return spawn(this.#cmdPath, args, {
+    return spawn(this.cmdPath, args, {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: this.#cwd.fsPath,
       // Set to true, to ensure this resolves properly on windows.
@@ -170,7 +170,7 @@ async function tryResolveNpmExecutable(cwd: vscode.Uri) {
 
   try {
     await vscode.workspace.fs.stat(npmExecutablePath);
-    return `"${npmExecutablePath.fsPath}"`;
+    return npmExecutablePath.fsPath;
   } catch {
     return undefined;
   }

--- a/src/executable/DprintExecutable.ts
+++ b/src/executable/DprintExecutable.ts
@@ -170,7 +170,7 @@ async function tryResolveNpmExecutable(cwd: vscode.Uri) {
 
   try {
     await vscode.workspace.fs.stat(npmExecutablePath);
-    return npmExecutablePath.fsPath;
+    return `"${npmExecutablePath.fsPath}"`;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Closes #33.

This fixes the problem with local node_modules, but I wonder if the quotes should be added at a higher level, for example, [when populating `cmdPath`](https://github.com/dprint/dprint-vscode/blob/main/src/executable/DprintExecutable.ts#L49) or if it is ok to do it only on `node_modules`.