### PR TITLE
fix: handle dprint process being killed by an outside force

### DIFF
--- a/src/editor-service/implementations/EditorService5.ts
+++ b/src/editor-service/implementations/EditorService5.ts
@@ -29,6 +29,7 @@ export class EditorService5 implements EditorService {
   private async startReadingStdout() {
     while (true) {
       try {
+        this._process.startProcessIfNotRunning();
         const messageId = await this._process.readInt();
         const messageKind = await this._process.readInt();
         const bodyLength = await this._process.readInt();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { DPRINT_CONFIG_FILENAME_GLOB } from "./constants";
 
 export class Notifier {
   readonly #outputChannel: vscode.OutputChannel;
@@ -38,7 +39,7 @@ export class Notifier {
     }
 
     try {
-      const result = await vscode.workspace.findFiles("**/{dprint,.dprint,.dprintrc}.json");
+      const result = await vscode.workspace.findFiles(`**/${DPRINT_CONFIG_FILENAME_GLOB}`, null, /* max results */ 1);
       if (result.length > 0) {
         this.#enableNotifications = true;
         return true;


### PR DESCRIPTION
This used to work. Probably broke with the schema version 4 refactor.