### PR TITLE
fix: ensure large files get formatted

### DIFF
--- a/src/editor-service/implementations/EditorService4.ts
+++ b/src/editor-service/implementations/EditorService4.ts
@@ -70,7 +70,7 @@ export class EditorService4 implements EditorService {
   }
 
   private async assertSuccessBytes() {
-    const buf = await this._process.readBuffer(4);
+    const buf = await this._process.readBufferExact(4);
     if (buf.length !== 4) {
       throw new Error(`Expected success byte array with length 4, but had length ${buf.length}.`);
     }
@@ -121,7 +121,7 @@ async function readString(process: EditorProcess) {
       // send "ready" to CLI
       await writeInt(process, 0);
     }
-    const nextBuffer = await process.readBuffer(stringSize - index);
+    const nextBuffer = await process.readBufferExact(stringSize - index);
     nextBuffer.copy(bytes, index, 0, nextBuffer.length);
     index += nextBuffer.length;
   }

--- a/src/editor-service/implementations/EditorService5.ts
+++ b/src/editor-service/implementations/EditorService5.ts
@@ -34,7 +34,7 @@ export class EditorService5 implements EditorService {
         const messageKind = await this._process.readInt();
         const bodyLength = await this._process.readInt();
 
-        const body = new BodyReader(await this._process.readBuffer(bodyLength));
+        const body = new BodyReader(await this._process.readBufferExact(bodyLength));
         await assertSuccessBytes(this._process);
 
         switch (messageKind) {
@@ -83,7 +83,7 @@ export class EditorService5 implements EditorService {
     }
 
     async function assertSuccessBytes(process: EditorProcess) {
-      const buf = await process.readBuffer(4);
+      const buf = await process.readBufferExact(4);
       if (buf.length !== 4) {
         throw new Error(`Expected success byte array with length 4, but had length ${buf.length}.`);
       }


### PR DESCRIPTION
This was just a silly bug I did where I used a method without realizing it was intended to return a buffer that was not the exact size provided, but instead the max size. This didn't previously surface because the editor service used to work in such a way that the buffer sizes would always be small, but now communication is much better which surfaced this issue in the plugin.

Closes #40