### PR TITLE
feat(configuration): add os-specific paths for dprint binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,16 +32,39 @@
       "type": "object",
       "title": "dprint",
       "properties": {
-        "dprint.path": {
+        "dprint.linuxPath": {
           "type": [
             "string",
             "null"
           ],
           "default": null,
-          "markdownDescription": "Specify a custom path for the dprint executable other than what's found on the path.",
+          "markdownDescription": "Specify a custom path for the dprint executable on Linux other than what's found on the path.",
           "scope": "resource",
           "examples": [
-            "/usr/bin/dprint",
+            "/usr/bin/dprint"
+          ]
+        },
+        "dprint.macOsPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Specify a custom path for the dprint executable on macOS other than what's found on the path.",
+          "scope": "resource",
+          "examples": [
+            "/usr/bin/dprint"
+          ]
+        },
+        "dprint.windowsPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Specify a custom path for the dprint executable on Windows other than what's found on the path.",
+          "scope": "resource",
+          "examples": [
             "C:\\some-dir\\dprint.exe"
           ]
         },

--- a/src/FolderService.ts
+++ b/src/FolderService.ts
@@ -166,7 +166,6 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
 
       function getRawPath() {
         let path: string | undefined;
-        console.log(config.get("linuxPath"));
         switch (process.platform) {
           case "linux":
             path = config.get("linuxPath");

--- a/src/FolderService.ts
+++ b/src/FolderService.ts
@@ -165,7 +165,20 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
       return path == null ? undefined : shellExpand(path);
 
       function getRawPath() {
-        const path = config.get("path");
+        let path: string | undefined;
+        console.log(config.get("linuxPath"));
+        switch (process.platform) {
+          case "linux":
+            path = config.get("linuxPath");
+            break;
+          case "darwin":
+            path = config.get("macOsPath");
+            break;
+          case "win32":
+            path = config.get("windowsPath");
+            break;
+        }
+
         return typeof path === "string" && path.trim().length > 0 ? path.trim() : undefined;
       }
     }


### PR DESCRIPTION
I found myself working on three different OSes and changing the path with Settings Sync became an hassle, so I'm proposing platform-specific paths for every OS.