### PR TITLE
fix: ensure duplicate processes don't appear when restarting or changing config

### DIFF
--- a/src/legacy/FolderService.ts
+++ b/src/legacy/FolderService.ts
@@ -135,7 +135,7 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
   }
 
   #setEditorService(newService: EditorService | undefined) {
-    this.#editorService?.kill();
+    this.#editorService?.killAndDispose();
     this.#editorService = newService;
   }
 

--- a/src/legacy/editor-service/EditorService.ts
+++ b/src/legacy/editor-service/EditorService.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 export interface EditorService {
-  kill(): void;
+  killAndDispose(): void;
   canFormat(filePath: string): Promise<boolean>;
   formatText(filePath: string, fileText: string, token: vscode.CancellationToken): Promise<string | undefined>;
 }

--- a/src/legacy/editor-service/implementations/EditorService4.ts
+++ b/src/legacy/editor-service/implementations/EditorService4.ts
@@ -17,7 +17,7 @@ export class EditorService4 implements EditorService {
     this._process.onExit(() => this._serialExecutor.clear());
   }
 
-  kill() {
+  killAndDispose() {
     // If graceful shutdown doesn't work soon enough
     // then kill the process
     const killTimeout = setTimeout(() => {


### PR DESCRIPTION
Executing the "dprint: Restart" process vscode command or changing any dprint.json files would cause multiple dprint to be spawned accidentally.