### PR TITLE
fix: add `allowTrailingCommas: true` to the fallback dprint.json(c) schema

### DIFF
--- a/src/legacy/ConfigJsonSchemaProvider.ts
+++ b/src/legacy/ConfigJsonSchemaProvider.ts
@@ -167,6 +167,7 @@ export class ConfigJsonSchemaProvider implements vscode.TextDocumentContentProvi
         description: "Plugin configuration.",
         type: "object",
       },
+      allowTrailingCommas: true,
     };
   }
 }


### PR DESCRIPTION
This fixes only part of Issue https://github.com/dprint/dprint-vscode/issues/94 . The other part of that issue will be fixed when PR https://github.com/dprint/dprint/pull/899 is merged and deployed.

This pull request only changes the json schema that is provided as a fallback when the proper/full schema cannot be provided by communication with the dprint executable (that communication with the executable is done by running `dprint editor-info` and combining all the json schemas mentioned in all the values of `configSchemaUrl` mentioned in the output of that command)