### PR TITLE
perf: avoid calling `process.report.getReport()` on startup

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -115,7 +115,6 @@ async function resolveLinuxFamily() {
   if (family != null) {
     return family;
   }
-
   return isProcessReportMusl() ? "musl" : "glibc";
 
   async function getFamilyFromLddPath() {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -3,7 +3,7 @@ import * as crypto from "node:crypto";
 import * as process from "node:process";
 import * as os from "os";
 import * as vscode from "vscode";
-import type { Logger } from "./logger";
+import { Instant, type Logger } from "./logger";
 
 // Over time, update the codebase to use this so it can be unit testable
 
@@ -89,10 +89,9 @@ export class RealEnvironment implements Environment {
   async getLinuxFamily() {
     const logger = this.#logger;
     if (cachedFamily == null) {
-      const startTime = performance.now();
+      const start = Instant.now();
       cachedFamily = await innerGet();
-      const duration = performance.now() - startTime;
-      logger.logDebug(`Resolved linux family to ${cachedFamily} in ${duration}ms`);
+      logger.logDebug(`Resolved linux family to ${cachedFamily} in ${start.elapsedMs()}ms`);
     }
     return cachedFamily;
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -101,7 +101,7 @@ export class RealEnvironment implements Environment {
           logger.logWarn("Should not be checking linux family on non-linux system.");
           return "glibc";
         }
-        return resolveLinuxFamily();
+        return resolveLinuxFamily(logger);
       } catch (err) {
         logger.logWarn("Error checking if musl. Assuming not.", err);
         return "glibc";
@@ -112,7 +112,7 @@ export class RealEnvironment implements Environment {
 
 // code adapted from https://github.com/lovell/detect-libc
 // Copyright Apache 2.0 license, the detect-libc maintainers
-async function resolveLinuxFamily() {
+async function resolveLinuxFamily(logger: Logger) {
   const family = await getFamilyFromLddPath() ?? await checkWithExecutables();
   if (family != null) {
     return family;
@@ -151,9 +151,10 @@ async function resolveLinuxFamily() {
       } else if (includes(bytes, "musl")) {
         return "musl";
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      logger.logDebug("Failed resolving family from lld path", err);
     }
+    logger.logDebug("Linux family not determined by lld path");
     return undefined;
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -89,7 +89,10 @@ export class RealEnvironment implements Environment {
   async getLinuxFamily() {
     const logger = this.#logger;
     if (cachedFamily == null) {
+      const startTime = performance.now();
       cachedFamily = await innerGet();
+      const duration = performance.now() - startTime;
+      logger.logDebug(`Resolved linux family to ${cachedFamily} in ${duration}ms`);
     }
     return cachedFamily;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,21 @@
 import type * as vscode from "vscode";
 
+export class Instant {
+  #time: number;
+
+  constructor(time: number) {
+    this.#time = time;
+  }
+
+  static now() {
+    return new Instant(performance.now());
+  }
+
+  elapsedMs() {
+    return performance.now() - this.#time;
+  }
+}
+
 export class Logger {
   readonly #outputChannel: vscode.OutputChannel;
   #debug = false;


### PR DESCRIPTION
As discovered and diagnosed by @jakebailey. The `process.report.getReport()` call takes several seconds on WSL probably due to vscode proxying all of node's networking code.

Co-authored-by: Jake Bailey <jakebailey@users.noreply.github.com>