### PR TITLE
fix: prevent logger debug output loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
+    "package": "npx vsce package",
     "compile": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "run:extension": "code --extensionDevelopmentPath=.",
     "watch": "npm run compile -- --watch",
@@ -84,11 +85,12 @@
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
-    "@types/node": "^20.14.11",
     "@types/glob": "^7.1.4",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^20.14.11",
     "@types/vscode": "^1.45.0",
     "@vscode/test-electron": "^2.1.5",
+    "@vscode/vsce": "^3.3.2",
     "esbuild": "^0.14.29",
     "glob": "^7.2.0",
     "mocha": "^9.2.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { getCombinedDprintConfig } from "./config";
 import { DPRINT_CONFIG_FILEPATH_GLOB } from "./constants";
 import type { ExtensionBackend } from "./ExtensionBackend";
 import { activateLegacy } from "./legacy/context";
-import { DprintOutputChannel, Logger } from "./logger";
+import { Logger } from "./logger";
 import { activateLsp } from "./lsp";
 
 class GlobalPluginState {
@@ -106,11 +106,11 @@ async function getAndSetNewGlobalState(context: vscode.ExtensionContext) {
   let logger: Logger | undefined = undefined;
   let backend: ExtensionBackend | undefined = undefined;
   try {
-    outputChannel = DprintOutputChannel.getOutputChannel();
-    logger = Logger.getLogger();
+    outputChannel = vscode.window.createOutputChannel("dprint");
+    logger = new Logger(outputChannel);
     backend = isLsp()
-      ? activateLsp(context, logger, outputChannel)
-      : activateLegacy(context, logger, outputChannel);
+      ? activateLsp(context, logger)
+      : activateLegacy(context, logger);
   } catch (err) {
     outputChannel?.dispose();
     throw err;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { getCombinedDprintConfig } from "./config";
 import { DPRINT_CONFIG_FILEPATH_GLOB } from "./constants";
 import type { ExtensionBackend } from "./ExtensionBackend";
 import { activateLegacy } from "./legacy/context";
-import { Logger } from "./logger";
+import { DprintOutputChannel, Logger } from "./logger";
 import { activateLsp } from "./lsp";
 
 class GlobalPluginState {
@@ -31,6 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const backend = globalState.extensionBackend;
   const logger = globalState.logger;
 
+  // reinitialize on workspace folder changes
   context.subscriptions.push(vscode.commands.registerCommand("dprint.restart", reInitializeBackend));
   context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(reInitializeBackend));
 
@@ -105,8 +106,8 @@ async function getAndSetNewGlobalState(context: vscode.ExtensionContext) {
   let logger: Logger | undefined = undefined;
   let backend: ExtensionBackend | undefined = undefined;
   try {
-    outputChannel = vscode.window.createOutputChannel("dprint");
-    logger = new Logger(outputChannel);
+    outputChannel = DprintOutputChannel.getOutputChannel();
+    logger = Logger.getLogger();
     backend = isLsp()
       ? activateLsp(context, logger, outputChannel)
       : activateLegacy(context, logger, outputChannel);

--- a/src/legacy/FolderService.ts
+++ b/src/legacy/FolderService.ts
@@ -9,7 +9,7 @@ import { createEditorService, type EditorService } from "./editor-service";
 export interface FolderServiceOptions {
   workspaceFolder: vscode.WorkspaceFolder;
   configUri: vscode.Uri | undefined;
-  outputChannel: vscode.OutputChannel;
+  logger: Logger;
 }
 
 /** Represents an instance of dprint for a single workspace folder */
@@ -24,7 +24,7 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
   #editorInfo: EditorInfo | undefined;
 
   constructor(opts: FolderServiceOptions) {
-    this.#logger = Logger.getLogger();
+    this.#logger = opts.logger;
     this.#workspaceFolder = opts.workspaceFolder;
     this.#configUri = opts.configUri;
     this.#environment = new RealEnvironment(this.#logger);

--- a/src/legacy/FolderService.ts
+++ b/src/legacy/FolderService.ts
@@ -24,7 +24,7 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
   #editorInfo: EditorInfo | undefined;
 
   constructor(opts: FolderServiceOptions) {
-    this.#logger = new Logger(opts.outputChannel);
+    this.#logger = Logger.getLogger();
     this.#workspaceFolder = opts.workspaceFolder;
     this.#configUri = opts.configUri;
     this.#environment = new RealEnvironment(this.#logger);
@@ -79,7 +79,6 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
       }
 
       this.#setEditorService(createEditorService(editorInfo.schemaVersion, this.#logger, dprintExe));
-
       this.#logger.logInfo(
         `Initialized dprint ${editorInfo.cliVersion}\n`
           + `  Folder: ${dprintExe.initializationFolderUri.fsPath}\n`

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { ancestorDirsContainConfigFile } from "../configFile";
 import { DPRINT_CONFIG_FILEPATH_GLOB } from "../constants";
 import type { EditorInfo } from "../executable/DprintExecutable";
+import { Logger } from "../logger";
 import { ObjectDisposedError } from "../utils";
 import { FolderService } from "./FolderService";
 
@@ -13,18 +14,18 @@ export interface FolderInfo {
 }
 
 export interface WorkspaceServiceOptions {
-  outputChannel: vscode.OutputChannel;
+  logger: Logger;
 }
 
 /** Handles creating dprint instances for each workspace folder. */
 export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
-  readonly #outputChannel: vscode.OutputChannel;
+  readonly #logger: Logger;
   readonly #folders: FolderService[] = [];
 
   #disposed = false;
 
   constructor(opts: WorkspaceServiceOptions) {
-    this.#outputChannel = opts.outputChannel;
+    this.#logger = opts.logger;
   }
 
   dispose() {
@@ -88,7 +89,7 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
           new FolderService({
             workspaceFolder: folder,
             configUri: subConfigUri,
-            outputChannel: this.#outputChannel,
+            logger: this.#logger,
           }),
         );
       }
@@ -105,7 +106,7 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
           new FolderService({
             workspaceFolder: folder,
             configUri: undefined,
-            outputChannel: this.#outputChannel,
+            logger: this.#logger,
           }),
         );
       }

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -74,7 +74,7 @@ export function activateLegacy(
           // This is necessary because by using the "associations" feature, a user may pattern
           // match against any file path then format that file using a certain plugin. Additionally,
           // we can't use the "includes" and "excludes" patterns from the config file because we
-          // want to ensure consistent path matching behavior... so don't want to rely on vscode's
+          // want to ensure consistent path matching behaviour... so don't want to rely on vscode's
           // pattern matching being the same.
           const pattern = new vscode.RelativePattern(folderInfo.uri, `**/*`);
           patterns.push(pattern);

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -1,20 +1,17 @@
 import * as vscode from "vscode";
 import type { ExtensionBackend } from "../ExtensionBackend";
 import type { Logger } from "../logger";
-import { HttpsTextDownloader, ObjectDisposedError } from "../utils";
-import ActivatedDisposables from "../utils/ActivatedDisposables";
+import { ActivatedDisposables, HttpsTextDownloader, ObjectDisposedError } from "../utils";
 import { ConfigJsonSchemaProvider } from "./ConfigJsonSchemaProvider";
 import { type FolderInfos, WorkspaceService } from "./WorkspaceService";
 
 export function activateLegacy(
   context: vscode.ExtensionContext,
   logger: Logger,
-  outputChannel: vscode.OutputChannel,
 ): ExtensionBackend {
-  const resourceStores = new ActivatedDisposables();
-  let formattingSubscription: vscode.Disposable | undefined = undefined;
+  const resourceStores = new ActivatedDisposables(logger);
   const workspaceService = new WorkspaceService({
-    outputChannel,
+    logger,
   });
   resourceStores.push(workspaceService);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 
 export class Instant {
   #time: number;
@@ -16,14 +16,32 @@ export class Instant {
   }
 }
 
+export class DprintOutputChannel {
+  static #outputChannel: vscode.OutputChannel | undefined;
+
+  static getOutputChannel() {
+    if (!DprintOutputChannel.#outputChannel) {
+      DprintOutputChannel.#outputChannel = vscode.window.createOutputChannel("dprint");
+    }
+    return DprintOutputChannel.#outputChannel;
+  }
+}
 export class Logger {
+  static #Logger: Logger | undefined;
   readonly #outputChannel: vscode.OutputChannel;
   #debug = false;
 
   static #hasFocused = false;
 
-  constructor(outputChannel: vscode.OutputChannel) {
-    this.#outputChannel = outputChannel;
+  private constructor() {
+    this.#outputChannel = DprintOutputChannel.getOutputChannel();
+  }
+
+  static getLogger() {
+    if (!Logger.#Logger) {
+      Logger.#Logger = new Logger();
+    }
+    return Logger.#Logger;
   }
 
   setDebug(enabled: boolean) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,32 +16,18 @@ export class Instant {
   }
 }
 
-export class DprintOutputChannel {
-  static #outputChannel: vscode.OutputChannel | undefined;
-
-  static getOutputChannel() {
-    if (!DprintOutputChannel.#outputChannel) {
-      DprintOutputChannel.#outputChannel = vscode.window.createOutputChannel("dprint");
-    }
-    return DprintOutputChannel.#outputChannel;
-  }
-}
 export class Logger {
-  static #Logger: Logger | undefined;
   readonly #outputChannel: vscode.OutputChannel;
   #debug = false;
 
   static #hasFocused = false;
 
-  private constructor() {
-    this.#outputChannel = DprintOutputChannel.getOutputChannel();
+  constructor(outputChannel: vscode.OutputChannel) {
+    this.#outputChannel = outputChannel;
   }
 
-  static getLogger() {
-    if (!Logger.#Logger) {
-      Logger.#Logger = new Logger();
-    }
-    return Logger.#Logger;
+  getOutputChannel() {
+    return this.#outputChannel;
   }
 
   setDebug(enabled: boolean) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 
 export class Instant {
   #time: number;

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -51,8 +51,8 @@ export function activateLsp(
         serverOptions,
         clientOptions,
       );
-      await client.start();
       resourceStores.push(client);
+      await client.start();
       logger.logInfo("Started experimental language server.");
     },
     async dispose() {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -7,14 +7,13 @@ import { RealEnvironment } from "./environment";
 import { DprintExecutable } from "./executable/DprintExecutable";
 import type { ExtensionBackend } from "./ExtensionBackend";
 import type { Logger } from "./logger";
-import ActivatedDisposables from "./utils/ActivatedDisposables";
+import { ActivatedDisposables } from "./utils";
 
 export function activateLsp(
   _context: vscode.ExtensionContext,
   logger: Logger,
-  outputChannel: vscode.OutputChannel,
 ): ExtensionBackend {
-  const resourceStores = new ActivatedDisposables();
+  const resourceStores = new ActivatedDisposables(logger);
   let client: LanguageClient | undefined;
 
   return {
@@ -45,7 +44,7 @@ export function activateLsp(
       };
       const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: "file" }],
-        outputChannel,
+        outputChannel: logger.getOutputChannel(),
       };
       client = new LanguageClient(
         "dprint",

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -7,12 +7,14 @@ import { RealEnvironment } from "./environment";
 import { DprintExecutable } from "./executable/DprintExecutable";
 import type { ExtensionBackend } from "./ExtensionBackend";
 import type { Logger } from "./logger";
+import ActivatedDisposables from "./utils/ActivatedDisposables";
 
 export function activateLsp(
   _context: vscode.ExtensionContext,
   logger: Logger,
   outputChannel: vscode.OutputChannel,
 ): ExtensionBackend {
+  const resourceStores = new ActivatedDisposables();
   let client: LanguageClient | undefined;
 
   return {
@@ -51,11 +53,11 @@ export function activateLsp(
         clientOptions,
       );
       await client.start();
+      resourceStores.push(client);
       logger.logInfo("Started experimental language server.");
     },
     async dispose() {
-      await client?.stop(2_000);
-      await client?.dispose(2_000);
+      resourceStores.dispose();
       client = undefined;
     },
   };

--- a/src/utils/ActivatedDisposables.ts
+++ b/src/utils/ActivatedDisposables.ts
@@ -1,0 +1,71 @@
+import { Disposable } from "vscode";
+import { Logger } from "../logger";
+
+type ExtendedDisposable = Disposable & {
+  stop?: () => Promise<void>;
+};
+
+/**
+ * ActivatedDisposables
+ *
+ * A utility class to manage disposables created during the `activate` lifecycle.
+ * Automatically disposes all registered resources when the parent is disposed.
+ */
+export class ActivatedDisposables {
+  private readonly _resourceStores: Disposable[] = [];
+  private readonly _logger = Logger.getLogger();
+
+  public push(...disposables: Disposable[]) {
+    this._resourceStores.push(...disposables);
+  }
+
+  public dispose() {
+    for (const disposable of this._resourceStores) {
+      try {
+        disposable.dispose();
+      } catch (err) {
+        this._logger.logWarn("Dispose failed (sync):", err);
+      }
+    }
+    this._resourceStores.length = 0;
+  }
+
+  public async disposeAsync(timeoutMs = 2000): Promise<void> {
+    const results = await Promise.allSettled(
+      this._resourceStores.map(d => this.#disposeWithStopSupport(d as ExtendedDisposable, timeoutMs)),
+    );
+    this._resourceStores.length = 0;
+
+    for (const res of results) {
+      if (res.status === "rejected") {
+        this._logger.logWarn("Dispose failed (async):", res.reason);
+      }
+    }
+  }
+
+  async #disposeWithStopSupport(
+    disposable: ExtendedDisposable,
+    timeoutMs: number,
+  ): Promise<void> {
+    try {
+      if (typeof disposable.stop === "function") {
+        await Promise.race([
+          disposable.stop(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error("Stop timeout exceeded")), timeoutMs)),
+        ]);
+      }
+
+      const result = disposable.dispose();
+      if (result instanceof Promise) {
+        await Promise.race([
+          result,
+          new Promise((_, reject) => setTimeout(() => reject(new Error("Dispose timeout exceeded")), timeoutMs)),
+        ]);
+      }
+    } catch (err) {
+      this._logger.logWarn("Failed to dispose/stop resource:", err);
+    }
+  }
+}
+
+export default ActivatedDisposables;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./ActivatedDisposables.js";
 export * from "./TextDownloader.js";
 
 export class ObjectDisposedError extends Error {}


### PR DESCRIPTION
### Problem

The extension's `Logger` was silently failing to output messages after backend reinitialization or window reloads.  
Root cause: The shared `OutputChannel` used by the logger was being registered in `context.subscriptions` and disposed prematurely by VSCode.

### Solution

This PR applies two key fixes:

1. **Make `Logger` and `OutputChannel` singletons**  
   - Ensures all backend instances share the same logging channel
   - Prevents multiple creations and accidental divergence

2. **Introduce `ActivatedDisposables` for backend-level resource management**  
   - Handles explicit cleanup of dynamically created resources (like LanguageClient)
   - Prevents shared resources like `Logger` or `OutputChannel` from being disposed by mistake
   - Separates lifecycle scope from `context.subscriptions`

### Outcome

- Logging works consistently across all extension states
- No more lost debug/info logs after switching between LSP and legacy backends
- Cleaner resource lifecycle tracking and more maintainable architecture

---

Let me know if you'd prefer this change to be split into two commits or PRs. Thanks!
