### PR TITLE
fix: wait for workspace to be initialized before checking for configuration files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,12 +76,16 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   });
 
-  const success = await reInitializeBackend();
-  if (success) {
-    logger.logInfo("Extension active!");
-  } else {
-    logger.logWarn("Extension failed to start.");
-  }
+  // initialize after a 1 second delay in order to work around
+  // https://github.com/dprint/dprint-vscode/issues/105
+  setTimeout(async () => {
+    const success = await reInitializeBackend();
+    if (success) {
+      logger.logInfo("Extension active!");
+    } else {
+      logger.logWarn("Extension failed to start.");
+    }
+  }, 1_000);
 
   async function reInitializeBackend() {
     try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,16 +76,13 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   });
 
-  // initialize after a 1 second delay in order to work around
-  // https://github.com/dprint/dprint-vscode/issues/105
-  setTimeout(async () => {
-    const success = await reInitializeBackend();
+  reInitializeBackend().then(success => {
     if (success) {
       logger.logInfo("Extension active!");
     } else {
       logger.logWarn("Extension failed to start.");
     }
-  }, 1_000);
+  });
 
   async function reInitializeBackend() {
     try {

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -3,7 +3,7 @@ import { ancestorDirsContainConfigFile } from "../configFile";
 import { DPRINT_CONFIG_FILEPATH_GLOB } from "../constants";
 import type { EditorInfo } from "../executable/DprintExecutable";
 import { Logger } from "../logger";
-import { ObjectDisposedError } from "../utils";
+import { findFiles, ObjectDisposedError } from "../utils";
 import { FolderService } from "./FolderService";
 
 export type FolderInfos = ReadonlyArray<Readonly<FolderInfo>>;
@@ -75,10 +75,10 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
       return [];
     }
 
-    const configFiles = await vscode.workspace.findFiles(
-      /* include */ DPRINT_CONFIG_FILEPATH_GLOB,
-      /* exclude */ "**/node_modules/**",
-    );
+    const configFiles = await findFiles({
+      include: DPRINT_CONFIG_FILEPATH_GLOB,
+      exclude: "**/node_modules/**",
+    });
 
     // Initialize the workspace folders with each sub configuration that's found.
     for (const folder of vscode.workspace.workspaceFolders) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -7,7 +7,7 @@ import { RealEnvironment } from "./environment";
 import { DprintExecutable } from "./executable/DprintExecutable";
 import type { ExtensionBackend } from "./ExtensionBackend";
 import type { Logger } from "./logger";
-import { ActivatedDisposables } from "./utils";
+import { ActivatedDisposables, findFiles } from "./utils";
 
 export function activateLsp(
   _context: vscode.ExtensionContext,
@@ -63,11 +63,11 @@ export function activateLsp(
 }
 
 async function workspaceHasConfigFile() {
-  const configFiles = await vscode.workspace.findFiles(
-    /* include */ DPRINT_CONFIG_FILEPATH_GLOB,
-    /* exclude */ "**/node_modules/**",
-    /* maxResults */ 1,
-  );
+  const configFiles = await findFiles({
+    include: DPRINT_CONFIG_FILEPATH_GLOB,
+    exclude: "**/node_modules/**",
+    maxResults: 1,
+  });
   if (configFiles.length > 0) {
     return true;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 export * from "./ActivatedDisposables.js";
 export * from "./TextDownloader.js";
 
@@ -10,4 +11,31 @@ export function shellExpand(path: string, env: { [prop: string]: string | undefi
     path = path.replace("~/", home + "/");
   }
   return path;
+}
+
+export async function waitWorkspaceInitialized() {
+  while (vscode.workspace.workspaceFolders == null || vscode.workspace.workspaceFolders.length === 0) {
+    await delay(500);
+  }
+}
+
+export async function findFiles(opts: {
+  include: string;
+  exclude: string;
+  maxResults?: number;
+}) {
+  // See https://github.com/dprint/dprint-vscode/issues/105 -- for some reason findFiles would
+  // return no results on very large projects
+  await waitWorkspaceInitialized();
+  // just in case, mitigate chance of findFiles not being ready by waiting a little bit of time
+  await delay(250);
+  return await vscode.workspace.findFiles(
+    opts.include,
+    opts.exclude,
+    opts.maxResults,
+  );
+}
+
+export function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,7 +27,7 @@ export async function findFiles(opts: {
   // See https://github.com/dprint/dprint-vscode/issues/105 -- for some reason findFiles would
   // return no results on very large projects when called too early on startup
   await waitWorkspaceInitialized();
-  // just in case, mitigate chance of findFiles not being ready by waiting a little bit of time
+  // just in case, mitigate more by waiting a little bit of time
   await delay(250);
   return await vscode.workspace.findFiles(
     opts.include,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,7 @@ export async function findFiles(opts: {
   maxResults?: number;
 }) {
   // See https://github.com/dprint/dprint-vscode/issues/105 -- for some reason findFiles would
-  // return no results on very large projects
+  // return no results on very large projects when called too early on startup
   await waitWorkspaceInitialized();
   // just in case, mitigate chance of findFiles not being ready by waiting a little bit of time
   await delay(250);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@ export function shellExpand(path: string, env: { [prop: string]: string | undefi
 
 export async function waitWorkspaceInitialized() {
   while (vscode.workspace.workspaceFolders == null || vscode.workspace.workspaceFolders.length === 0) {
-    await delay(500);
+    await delay(1_00);
   }
 }
 


### PR DESCRIPTION
Probably closes https://github.com/dprint/dprint-vscode/issues/105