### PR TITLE
fix: fallback to global dprint when disallowing local `"dprint.path"` config

### DIFF
--- a/src/legacy/FolderService.ts
+++ b/src/legacy/FolderService.ts
@@ -62,13 +62,6 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
     this.#logger.setDebug(config.verbose);
     this.#setEditorService(undefined);
 
-    // prompt for approval if using a workspace-configured path
-    const approved = await this.#approvedPaths.promptForApproval(config.pathInfo);
-    if (!approved) {
-      this.#logger.logWarn("Custom dprint path was not approved by user.");
-      return false;
-    }
-
     const dprintExe = await this.#getDprintExecutable();
     const isInstalled = await dprintExe.checkInstalled();
     this.#assertNotDisposed();
@@ -156,7 +149,8 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
   #getDprintExecutable() {
     const config = this.#getConfig();
     return DprintExecutable.create({
-      cmdPath: config.pathInfo?.path,
+      approvedPaths: this.#approvedPaths,
+      pathInfo: config.pathInfo,
       // It's important that we always use the workspace folder as the
       // cwd for the process instead of possibly the sub directory because
       // we don't want the dprint process to hold a resource lock on a

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -29,16 +29,12 @@ export function activateLsp(
       const rootUri = vscode.workspace.workspaceFolders?.[0].uri;
       const config = getCombinedDprintConfig(vscode.workspace.workspaceFolders ?? []);
 
-      // prompt for approval if using a workspace-configured path
-      const approved = await approvedPaths.promptForApproval(config.pathInfo);
-      if (!approved) {
-        logger.logWarn("Custom dprint path was not approved by user.");
-        return;
-      }
-
       const cmdPath = await DprintExecutable.resolveCmdPath({
-        cmdPath: config.pathInfo?.path,
-        cwd: rootUri,
+        approvedPaths,
+        pathInfo: config.pathInfo,
+        cwd: rootUri!,
+        configUri: undefined,
+        verbose: config.verbose,
         logger,
         environment: new RealEnvironment(logger),
       });
@@ -47,7 +43,7 @@ export function activateLsp(
         args.push("--verbose");
       }
       const serverOptions: ServerOptions = {
-        command: cmdPath ?? "dprint",
+        command: cmdPath,
         args,
         options: {
           shell: true,


### PR DESCRIPTION
I realized this while working on the same feature in Deno's extension.