### PR TITLE
feat: improve notification when no configuration file is found

### DIFF
--- a/src/ExtensionBackend.ts
+++ b/src/ExtensionBackend.ts
@@ -3,4 +3,5 @@ import type * as vscode from "vscode";
 export interface ExtensionBackend extends vscode.Disposable {
   readonly isLsp: boolean;
   reInitialize(): Promise<void>;
+  dispose(): void | Promise<void>;
 }

--- a/src/legacy/FolderService.ts
+++ b/src/legacy/FolderService.ts
@@ -41,8 +41,8 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
     return this.#workspaceFolder.uri;
   }
 
-  dispose() {
-    this.#setEditorService(undefined);
+  async dispose() {
+    await this.#setEditorService(undefined);
     this.#disposed = true;
   }
 
@@ -60,7 +60,7 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
     this.#assertNotDisposed();
     const config = this.#getConfig();
     this.#logger.setDebug(config.verbose);
-    this.#setEditorService(undefined);
+    await this.#setEditorService(undefined);
 
     const dprintExe = await this.#getDprintExecutable();
     const isInstalled = await dprintExe.checkInstalled();
@@ -92,7 +92,7 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
       return true;
     } catch (err) {
       // clear
-      this.#setEditorService(undefined);
+      await this.#setEditorService(undefined);
       this.#editorInfo = undefined;
 
       if (err instanceof ObjectDisposedError) {
@@ -141,8 +141,8 @@ export class FolderService implements vscode.DocumentFormattingEditProvider {
     }
   }
 
-  #setEditorService(newService: EditorService | undefined) {
-    this.#editorService?.killAndDispose();
+  async #setEditorService(newService: EditorService | undefined) {
+    await this.#editorService?.killAndDispose();
     this.#editorService = newService;
   }
 

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -48,7 +48,15 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
     token: vscode.CancellationToken,
   ) {
     const folder = this.#getFolderForUri(document.uri);
-    return folder?.provideDocumentFormattingEdits(document, options, token);
+    if (!folder) {
+      if (this.#folders.length === 0) {
+        vscode.window.showErrorMessage(
+          "dprint: No configuration file found. Run 'dprint init' or check your project root to enable formatting.",
+        );
+      }
+      return [];
+    }
+    return folder.provideDocumentFormattingEdits(document, options, token);
   }
 
   #getFolderForUri(uri: vscode.Uri) {

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -31,8 +31,8 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
     this.#logger = opts.logger;
   }
 
-  dispose() {
-    this.#clearFolders();
+  async dispose() {
+    await this.#clearFolders();
     this.#disposed = true;
   }
 
@@ -63,17 +63,15 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
     return bestMatch;
   }
 
-  #clearFolders() {
-    for (const folder of this.#folders) {
-      folder.dispose();
-    }
+  async #clearFolders() {
+    await Promise.all(this.#folders.map(f => f.dispose()));
     this.#folders.length = 0; // clear
   }
 
   async initializeFolders(): Promise<FolderInfos> {
     this.#assertNotDisposed();
 
-    this.#clearFolders();
+    await this.#clearFolders();
     if (vscode.workspace.workspaceFolders == null) {
       return [];
     }

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -83,6 +83,15 @@ export function activateLegacy(
           patterns.push(pattern);
         }
       }
+
+      // If no folders were initialized with a config file, register for all workspace folders
+      // to provide a better error message when formatting is triggered.
+      if (patterns.length === 0 && vscode.workspace.workspaceFolders != null) {
+        for (const folder of vscode.workspace.workspaceFolders) {
+          patterns.push(new vscode.RelativePattern(folder.uri, `**/*`));
+        }
+      }
+
       return patterns;
     }
   }

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -42,10 +42,10 @@ export function activateLegacy(
       }
       logger.logDebug("Initialized legacy backend.");
     },
-    dispose() {
+    async dispose() {
       formattingSubscription?.dispose();
       formattingSubscription = undefined;
-      resourceStores.dispose();
+      await resourceStores.disposeAsync();
       logger.logDebug("Disposed legacy backend.");
     },
   };

--- a/src/legacy/editor-service/EditorService.ts
+++ b/src/legacy/editor-service/EditorService.ts
@@ -1,7 +1,7 @@
 import type * as vscode from "vscode";
 
 export interface EditorService {
-  killAndDispose(): void;
+  killAndDispose(): Promise<void>;
   canFormat(filePath: string): Promise<boolean>;
   formatText(filePath: string, fileText: string, token: vscode.CancellationToken): Promise<string | undefined>;
 }

--- a/src/legacy/editor-service/implementations/EditorService4.ts
+++ b/src/legacy/editor-service/implementations/EditorService4.ts
@@ -18,7 +18,7 @@ export class EditorService4 implements EditorService {
     this._process.onExit(() => this._serialExecutor.clear());
   }
 
-  killAndDispose() {
+  async killAndDispose() {
     // If graceful shutdown doesn't work soon enough
     // then kill the process
     const killTimeout = setTimeout(() => {
@@ -26,10 +26,14 @@ export class EditorService4 implements EditorService {
     }, 1_000);
 
     // send a graceful shutdown signal
-    writeInt(this._process, 0).finally(() => {
+    try {
+      await writeInt(this._process, 0);
+    } catch {
+      // ignore
+    } finally {
       this._process.kill();
       clearTimeout(killTimeout);
-    }).catch(() => {/* ignore */});
+    }
   }
 
   canFormat(filePath: string) {

--- a/src/legacy/editor-service/implementations/EditorService5.ts
+++ b/src/legacy/editor-service/implementations/EditorService5.ts
@@ -101,10 +101,13 @@ export class EditorService5 implements EditorService {
   }
 
   async killAndDispose() {
+    // Set disposed FIRST to prevent startReadingStdout from restarting
+    // the process when it detects the exit during graceful shutdown.
+    this._disposed = true;
+
     // If graceful shutdown doesn't work soon enough
     // then kill the process
     const killTimeout = setTimeout(() => {
-      this._disposed = true;
       this._process.kill();
     }, 1_000);
 
@@ -114,7 +117,6 @@ export class EditorService5 implements EditorService {
     } catch {
       // ignore
     } finally {
-      this._disposed = true;
       this._process.kill();
       clearTimeout(killTimeout);
     }

--- a/src/legacy/editor-service/implementations/EditorService5.ts
+++ b/src/legacy/editor-service/implementations/EditorService5.ts
@@ -100,7 +100,7 @@ export class EditorService5 implements EditorService {
     }
   }
 
-  killAndDispose() {
+  async killAndDispose() {
     // If graceful shutdown doesn't work soon enough
     // then kill the process
     const killTimeout = setTimeout(() => {
@@ -109,11 +109,15 @@ export class EditorService5 implements EditorService {
     }, 1_000);
 
     // send a graceful shutdown signal
-    this.gracefulClose().finally(() => {
+    try {
+      await this.gracefulClose();
+    } catch {
+      // ignore
+    } finally {
       this._disposed = true;
       this._process.kill();
       clearTimeout(killTimeout);
-    }).catch(() => {/* ignore */});
+    }
   }
 
   canFormat(filePath: string) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -19,8 +19,11 @@ export function activateLsp(
   return {
     isLsp: true,
     async reInitialize() {
-      await client?.stop(2_000);
-      client = undefined;
+      if (client) {
+        await client.stop(2_000);
+        client.dispose();
+        client = undefined;
+      }
       if (!(await workspaceHasConfigFile())) {
         logger.logInfo("Configuration file not found.");
         return;
@@ -58,13 +61,16 @@ export function activateLsp(
         serverOptions,
         clientOptions,
       );
-      resourceStores.push(client);
       await client.start();
       logger.logInfo("Started experimental language server.");
     },
     async dispose() {
+      if (client) {
+        await client.stop(2_000);
+        client.dispose();
+        client = undefined;
+      }
       resourceStores.dispose();
-      client = undefined;
     },
   };
 


### PR DESCRIPTION
This PR improves the user experience when dprint is configured as the default formatter but no configuration file exists in the workspace. Instead of seeing a generic and misleading VS Code error message, the user will now see a helpful toast from dprint explaining that no configuration file was found.\n\nFixes #134