### PR TITLE
fix: register formatter for jsonc and json language IDs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings to LF in the repo
+* text eol=lf

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -136,6 +136,30 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
         }
       }
     }
+    // add a global fallback folder
+    const rootParams = {
+        uri: vscode.Uri.file(process.platform === "win32" ? "C:\\" : "/"),
+        name: "Global",
+        index: -1
+    } as vscode.WorkspaceFolder;
+    const globalFolderService = new FolderService({
+        approvedPaths: this.#approvedPaths,
+        workspaceFolder: rootParams,
+        configUri: undefined,
+        logger: this.#logger,
+    });
+    if (await globalFolderService.initialize()) {
+        const editorInfo = globalFolderService.getEditorInfo();
+        if (editorInfo != null) {
+            allEditorInfos.push({ uri: globalFolderService.uri, editorInfo });
+            this.#folders.push(globalFolderService);
+        } else {
+            globalFolderService.dispose();
+        }
+    } else {
+        globalFolderService.dispose();
+    }
+
     return allEditorInfos;
   }
 }

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -33,6 +33,8 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
   readonly #pluginSuggestionShown = new Set<string>();
   /** Workspace folder URIs we already offered "Create dprint.jsonc" for. */
   readonly #createConfigOfferShown = new Set<string>();
+  /** Folder URIs we already suggested adding code-workspace association for. */
+  readonly #codeWorkspaceAssociationSuggested = new Set<string>();
 
   #disposed = false;
 
@@ -58,27 +60,59 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
     token: vscode.CancellationToken,
   ) {
     const folder = this.#getFolderForUri(document.uri);
-    const result = await folder?.provideDocumentFormattingEdits(document, options, token);
-    if (result === undefined) {
-      if (folder != null) {
-        this.#maybeSuggestPlugin(document, folder);
-      } else {
+    if (folder == null) {
+      if (this.#folders.length === 0) {
+        this.#logger.logWarn("Format requested but no dprint configuration file found.");
+        vscode.window.showErrorMessage(
+          "dprint: No configuration file found. Run 'dprint init' or add a dprint.jsonc to your project root to enable formatting.",
+        );
         this.#maybeOfferCreateConfig(document);
       }
+      return [];
+    }
+    const result = await folder.provideDocumentFormattingEdits(document, options, token);
+    if (result === undefined) {
+      this.#maybeSuggestPlugin(document, folder);
     }
     return result;
   }
 
-  #maybeSuggestPlugin(document: vscode.TextDocument, folder: FolderService) {
-    const langId = document.languageId;
-    if (!ALL_DPRINT_SUPPORTABLE_LANGUAGE_IDS.has(langId)) {
+  #maybeSuggestCodeWorkspaceAssociation(_document: vscode.TextDocument, folder: FolderService) {
+    const key = folder.uri.toString();
+    if (this.#codeWorkspaceAssociationSuggested.has(key)) {
       return;
     }
+    this.#codeWorkspaceAssociationSuggested.add(key);
+    const configDocs = "Config docs";
+    this.#logger.logInfo(
+      "dprint JSON plugin does not match .code-workspace by default. Add \"**/*.code-workspace\" to json.associations in dprint config.",
+    );
+    vscode.window.showInformationMessage(
+      "dprint: The JSON plugin doesn't match .code-workspace files by default. Add \"**/*.code-workspace\" to the json.associations array in your dprint config, then run Dprint: Restart.",
+      configDocs,
+    ).then((choice) => {
+      if (choice === configDocs) {
+        vscode.env.openExternal(vscode.Uri.parse("https://dprint.dev/config#associations"));
+      }
+    });
+  }
+
+  #maybeSuggestPlugin(document: vscode.TextDocument, folder: FolderService) {
+    const langId = document.languageId;
     const editorInfo = folder.getEditorInfo();
     if (editorInfo == null) {
       return;
     }
     const supported = getSupportedLanguageIds(editorInfo.plugins);
+
+    if (langId === "code-workspace" && supported.includes("jsonc")) {
+      this.#maybeSuggestCodeWorkspaceAssociation(document, folder);
+      return;
+    }
+
+    if (!ALL_DPRINT_SUPPORTABLE_LANGUAGE_IDS.has(langId)) {
+      return;
+    }
     if (supported.includes(langId)) {
       return;
     }

--- a/src/legacy/WorkspaceService.ts
+++ b/src/legacy/WorkspaceService.ts
@@ -4,7 +4,13 @@ import { ancestorDirsContainConfigFile, discoverWorkspaceConfigFiles } from "../
 import type { EditorInfo } from "../executable/DprintExecutable";
 import { Logger } from "../logger";
 import { ObjectDisposedError } from "../utils";
+import { addOrUncommentPlugin, findOrCreateConfigFile } from "./dprintConfigEditor";
 import { FolderService } from "./FolderService";
+import {
+  ALL_DPRINT_SUPPORTABLE_LANGUAGE_IDS,
+  getSupportedLanguageIds,
+  LANGUAGE_ID_TO_PLUGIN_SUGGESTION,
+} from "./supportedLanguages";
 
 export type FolderInfos = ReadonlyArray<Readonly<FolderInfo>>;
 
@@ -23,6 +29,10 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
   readonly #approvedPaths: ApprovedConfigPaths;
   readonly #logger: Logger;
   readonly #folders: FolderService[] = [];
+  /** Keys: `${folderUri}:${languageId}` — avoid spamming plugin suggestion. */
+  readonly #pluginSuggestionShown = new Set<string>();
+  /** Workspace folder URIs we already offered "Create dprint.jsonc" for. */
+  readonly #createConfigOfferShown = new Set<string>();
 
   #disposed = false;
 
@@ -42,13 +52,105 @@ export class WorkspaceService implements vscode.DocumentFormattingEditProvider {
     }
   }
 
-  provideDocumentFormattingEdits(
+  async provideDocumentFormattingEdits(
     document: vscode.TextDocument,
     options: vscode.FormattingOptions,
     token: vscode.CancellationToken,
   ) {
     const folder = this.#getFolderForUri(document.uri);
-    return folder?.provideDocumentFormattingEdits(document, options, token);
+    const result = await folder?.provideDocumentFormattingEdits(document, options, token);
+    if (result === undefined) {
+      if (folder != null) {
+        this.#maybeSuggestPlugin(document, folder);
+      } else {
+        this.#maybeOfferCreateConfig(document);
+      }
+    }
+    return result;
+  }
+
+  #maybeSuggestPlugin(document: vscode.TextDocument, folder: FolderService) {
+    const langId = document.languageId;
+    if (!ALL_DPRINT_SUPPORTABLE_LANGUAGE_IDS.has(langId)) {
+      return;
+    }
+    const editorInfo = folder.getEditorInfo();
+    if (editorInfo == null) {
+      return;
+    }
+    const supported = getSupportedLanguageIds(editorInfo.plugins);
+    if (supported.includes(langId)) {
+      return;
+    }
+    const key = `${folder.uri.toString()}:${langId}`;
+    if (this.#pluginSuggestionShown.has(key)) {
+      return;
+    }
+    this.#pluginSuggestionShown.add(key);
+    const suggestion = LANGUAGE_ID_TO_PLUGIN_SUGGESTION[langId];
+    if (suggestion == null) {
+      return;
+    }
+    const addToConfig = "Add to config";
+    const openDocs = "Open plugin docs";
+    this.#logger.logInfo(
+      `dprint could format this ${langId} file with the ${suggestion.name} plugin. Add it to your dprint config.`,
+    );
+    vscode.window.showInformationMessage(
+      `dprint could format this file with the ${suggestion.name} plugin. Add it to your dprint config.`,
+      addToConfig,
+      openDocs,
+    ).then(async (choice) => {
+      if (choice === openDocs) {
+        vscode.env.openExternal(vscode.Uri.parse(suggestion.helpUrl));
+        return;
+      }
+      if (choice === addToConfig) {
+        try {
+          const { configUri, created } = await findOrCreateConfigFile(folder.uri, this.#logger);
+          await addOrUncommentPlugin(configUri, suggestion.pluginUrl, this.#logger, {
+            openInEditor: true,
+          });
+          if (created) {
+            this.#logger.logInfo("Restart dprint (Dprint: Restart) or change config to load the new file.");
+          }
+        } catch (err) {
+          this.#logger.logError("Failed to add plugin to config.", err);
+          vscode.window.showErrorMessage(`Failed to update dprint config: ${err}`);
+        }
+      }
+    });
+  }
+
+  #maybeOfferCreateConfig(document: vscode.TextDocument) {
+    const wf = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (wf == null) return;
+    const key = wf.uri.toString();
+    if (this.#createConfigOfferShown.has(key)) return;
+    if (!this.#isDprintSetAsFormatter(document.uri)) return;
+    this.#createConfigOfferShown.add(key);
+    const create = "Create dprint.jsonc";
+    this.#logger.logInfo("No dprint config found; dprint is set as formatter. Offering to create dprint.jsonc.");
+    vscode.window.showInformationMessage(
+      "No dprint config file found. Create a starter dprint.jsonc with commented plugin options?",
+      create,
+    ).then(async (choice) => {
+      if (choice !== create) return;
+      try {
+        const { createBarebonesConfigAndOpen } = await import("./dprintConfigEditor");
+        await createBarebonesConfigAndOpen(wf.uri, this.#logger);
+        this.#logger.logInfo("Created dprint.jsonc. Uncomment the plugins you need, then run Dprint: Restart.");
+      } catch (err) {
+        this.#logger.logError("Failed to create dprint config.", err);
+        vscode.window.showErrorMessage(`Failed to create dprint config: ${err}`);
+      }
+    });
+  }
+
+  /** Whether dprint is set as default formatter (workspace or user settings). */
+  #isDprintSetAsFormatter(uri: vscode.Uri): boolean {
+    const formatter = vscode.workspace.getConfiguration("editor", uri).get<string>("defaultFormatter");
+    return formatter === "dprint.dprint";
   }
 
   #getFolderForUri(uri: vscode.Uri) {

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -4,6 +4,7 @@ import type { ExtensionBackend } from "../ExtensionBackend";
 import type { Logger } from "../logger";
 import { ActivatedDisposables, HttpsTextDownloader, ObjectDisposedError } from "../utils";
 import { ConfigJsonSchemaProvider } from "./ConfigJsonSchemaProvider";
+import { getSupportedLanguageIds } from "./supportedLanguages";
 import { type FolderInfos, WorkspaceService } from "./WorkspaceService";
 
 export function activateLegacy(
@@ -54,13 +55,14 @@ export function activateLegacy(
       return;
     }
 
+    const allPlugins = allFolderInfos.flatMap(f => f.editorInfo.plugins);
+    const supportedLanguageIds = getSupportedLanguageIds(allPlugins);
     const documentSelectors: vscode.DocumentFilter[] = [
       ...formattingPatterns.map(pattern => ({ scheme: "file", pattern })),
-      // Explicitly register for jsonc and json so the extension appears as a formatter
-      // choice for these languages (VS Code does not reliably associate glob-only
-      // selectors with language IDs like jsonc).
-      { scheme: "file", language: "jsonc" },
-      { scheme: "file", language: "json" },
+      // Explicitly register for each language we have a plugin for, so the extension
+      // appears in the formatter list (VS Code does not reliably associate glob-only
+      // selectors with language IDs like jsonc, yaml, graphql, etc.).
+      ...supportedLanguageIds.map(language => ({ scheme: "file" as const, language })),
     ];
     resourceStores.push(
       vscode.languages.registerDocumentFormattingEditProvider(

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -12,6 +12,7 @@ export function activateLegacy(
   approvedPaths: ApprovedConfigPaths,
 ): ExtensionBackend {
   const resourceStores = new ActivatedDisposables(logger);
+  let formattingSubscription: vscode.Disposable | undefined;
   const workspaceService = new WorkspaceService({
     approvedPaths,
     logger,
@@ -43,12 +44,17 @@ export function activateLegacy(
       logger.logDebug("Initialized legacy backend.");
     },
     dispose() {
+      formattingSubscription?.dispose();
+      formattingSubscription = undefined;
       resourceStores.dispose();
       logger.logDebug("Disposed legacy backend.");
     },
   };
 
   function trySetFormattingSubscriptionFromFolderInfos(allFolderInfos: FolderInfos) {
+    formattingSubscription?.dispose();
+    formattingSubscription = undefined;
+
     const formattingPatterns = getFormattingPatterns();
 
     if (formattingPatterns.length === 0) {
@@ -64,15 +70,13 @@ export function activateLegacy(
       // selectors with language IDs like jsonc, yaml, graphql, etc.).
       ...supportedLanguageIds.map(language => ({ scheme: "file" as const, language })),
     ];
-    resourceStores.push(
-      vscode.languages.registerDocumentFormattingEditProvider(
-        documentSelectors,
-        {
-          provideDocumentFormattingEdits(document, options, token) {
-            return workspaceService.provideDocumentFormattingEdits(document, options, token);
-          },
+    formattingSubscription = vscode.languages.registerDocumentFormattingEditProvider(
+      documentSelectors,
+      {
+        provideDocumentFormattingEdits(document, options, token) {
+          return workspaceService.provideDocumentFormattingEdits(document, options, token);
         },
-      ),
+      },
     );
 
     function getFormattingPatterns() {

--- a/src/legacy/context.ts
+++ b/src/legacy/context.ts
@@ -54,9 +54,17 @@ export function activateLegacy(
       return;
     }
 
+    const documentSelectors: vscode.DocumentFilter[] = [
+      ...formattingPatterns.map(pattern => ({ scheme: "file", pattern })),
+      // Explicitly register for jsonc and json so the extension appears as a formatter
+      // choice for these languages (VS Code does not reliably associate glob-only
+      // selectors with language IDs like jsonc).
+      { scheme: "file", language: "jsonc" },
+      { scheme: "file", language: "json" },
+    ];
     resourceStores.push(
       vscode.languages.registerDocumentFormattingEditProvider(
-        formattingPatterns.map(pattern => ({ scheme: "file", pattern })),
+        documentSelectors,
         {
           provideDocumentFormattingEdits(document, options, token) {
             return workspaceService.provideDocumentFormattingEdits(document, options, token);

--- a/src/legacy/dprintConfigEditor.ts
+++ b/src/legacy/dprintConfigEditor.ts
@@ -1,0 +1,186 @@
+import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import * as vscode from "vscode";
+import { DPRINT_CONFIG_FILE_NAMES } from "../constants";
+import { Logger } from "../logger";
+import { BAREBOONES_DPRINT_JSONC } from "./supportedLanguages";
+
+/**
+ * Extract a short plugin key from a plugin URL for matching commented lines.
+ * e.g. "https://plugins.dprint.dev/json-0.21.1.wasm" -> "json"
+ *      "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm" -> "malva"
+ */
+export function pluginSlugFromUrl(pluginUrl: string): string {
+  try {
+    const pathPart = new URL(pluginUrl).pathname.replace(/^\//, "");
+    const lastSegment = pathPart.split("/").pop() || "";
+    const withoutExt = lastSegment.replace(/\.wasm$/i, "");
+    const withoutVersion = withoutExt.replace(/-[vV]?\d+\.\d+.*$/, "");
+    return withoutVersion || withoutExt;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Find an existing dprint config file in the given folder or its ancestors.
+ */
+export async function findConfigInFolderOrAncestors(folderUri: vscode.Uri): Promise<vscode.Uri | undefined> {
+  let dir = folderUri.fsPath;
+  for (let i = 0; i < 20; i++) {
+    for (const name of DPRINT_CONFIG_FILE_NAMES) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) {
+        return vscode.Uri.file(candidate);
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Create a barebones dprint.jsonc at the given folder root with commented plugin lines,
+ * then open it in the editor. Returns the config file URI.
+ */
+export async function createBarebonesConfigAndOpen(
+  folderUri: vscode.Uri,
+  logger: Logger,
+): Promise<vscode.Uri> {
+  const configUri = vscode.Uri.joinPath(folderUri, "dprint.jsonc");
+  const encoder = new TextEncoder();
+  await vscode.workspace.fs.writeFile(
+    configUri,
+    encoder.encode(BAREBOONES_DPRINT_JSONC),
+  );
+  logger.logInfo(`Created ${configUri.fsPath}`);
+  const doc = await vscode.workspace.openTextDocument(configUri);
+  await vscode.window.showTextDocument(doc);
+  return configUri;
+}
+
+/**
+ * Ensure a dprint config exists for the folder: use existing or create barebones.
+ * Returns the config URI and whether we created it.
+ */
+export async function findOrCreateConfigFile(
+  folderUri: vscode.Uri,
+  logger: Logger,
+): Promise<{ configUri: vscode.Uri; created: boolean }> {
+  const existing = await findConfigInFolderOrAncestors(folderUri);
+  if (existing) {
+    return { configUri: existing, created: false };
+  }
+  const configUri = await createBarebonesConfigAndOpen(folderUri, logger);
+  return { configUri, created: true };
+}
+
+/**
+ * Check if a line is a commented-out plugin URL that matches the given plugin.
+ */
+function isCommentedPluginLine(line: string, pluginUrl: string, slug: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("//")) return false;
+  const afterComment = trimmed.slice(2).trim();
+  if (!afterComment.startsWith('"') || !afterComment.includes("plugins.dprint.dev")) return false;
+  return afterComment.includes(slug) || afterComment.includes(pluginUrl);
+}
+
+/**
+ * Uncomment a line: remove leading // and trim.
+ */
+function uncommentLine(line: string): string {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("//")) {
+    return trimmed.slice(2).trimStart();
+  }
+  return line;
+}
+
+/**
+ * Add the plugin to the config or uncomment an existing commented plugin line.
+ * Reads the file as text, applies the edit, writes back, and optionally opens the doc.
+ */
+export async function addOrUncommentPlugin(
+  configUri: vscode.Uri,
+  pluginUrl: string,
+  logger: Logger,
+  options: { openInEditor?: boolean } = {},
+): Promise<void> {
+  const slug = pluginSlugFromUrl(pluginUrl);
+  const doc = await vscode.workspace.openTextDocument(configUri);
+  let content = doc.getText();
+
+  const lines = content.split(/\r?\n/);
+  let modified = false;
+  const newLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (isCommentedPluginLine(line, pluginUrl, slug)) {
+      newLines.push(uncommentLine(line));
+      modified = true;
+      logger.logInfo(`Uncommented plugin line for ${slug} in ${configUri.fsPath}`);
+    } else {
+      newLines.push(line);
+    }
+  }
+
+  if (!modified) {
+    const alreadyPresent = newLines.some(
+      (l) => l.includes(pluginUrl) && !l.trim().startsWith("//"),
+    );
+    if (!alreadyPresent) {
+      const fullContent = newLines.join("\n");
+      const inserted = addPluginToPluginsArray(fullContent, pluginUrl);
+      if (inserted != null) {
+        content = inserted;
+        modified = true;
+        logger.logInfo(`Added plugin ${pluginUrl} to ${configUri.fsPath}`);
+      } else {
+        content = fullContent;
+      }
+    } else {
+      content = newLines.join("\n");
+    }
+  } else {
+    content = newLines.join("\n");
+  }
+
+  if (modified) {
+    const encoder = new TextEncoder();
+    await vscode.workspace.fs.writeFile(configUri, encoder.encode(content));
+  }
+
+  if (options.openInEditor !== false) {
+    const d = await vscode.workspace.openTextDocument(configUri);
+    await vscode.window.showTextDocument(d);
+  }
+}
+
+/**
+ * Insert plugin URL into the "plugins" array. Handles JSON/JSONC with trailing commas.
+ * Does not add if the URL is already present (uncommented). Returns new content or null if insertion point not found.
+ */
+function addPluginToPluginsArray(content: string, pluginUrl: string): string | null {
+  const pluginsArrayMatch = content.match(/"plugins"\s*:\s*\[/);
+  if (!pluginsArrayMatch) return null;
+  const openStart = pluginsArrayMatch.index ?? 0;
+  const openEnd = openStart + pluginsArrayMatch[0].length;
+  const afterOpen = content.slice(openEnd);
+  let depth = 1;
+  let i = 0;
+  for (; i < afterOpen.length && depth > 0; i++) {
+    const c = afterOpen[i];
+    if (c === "[") depth++;
+    else if (c === "]") depth--;
+  }
+  const pluginsContent = afterOpen.slice(0, i - 1);
+  const afterArray = afterOpen.slice(i - 1);
+  const trimmed = pluginsContent.trimEnd();
+  const needsComma = trimmed.length > 0 && !trimmed.endsWith(",");
+  const newEntry = (needsComma ? "," : "") + `\n    "${pluginUrl}"`;
+  return content.slice(0, openEnd) + pluginsContent + newEntry + afterArray;
+}

--- a/src/legacy/supportedLanguages.ts
+++ b/src/legacy/supportedLanguages.ts
@@ -1,0 +1,183 @@
+import type { PluginInfo } from "../executable/DprintExecutable";
+
+/**
+ * Maps dprint plugin file extensions and file names to VS Code language IDs.
+ * Used so we only register as a formatter for languages we actually have a plugin for,
+ * and so VS Code shows dprint in the formatter list for those languages (glob-only
+ * selectors are not reliably associated with language IDs like jsonc).
+ *
+ * See https://code.visualstudio.com/docs/languages/identifiers and
+ * https://dprint.dev/plugins/
+ */
+const EXTENSION_AND_FILENAME_TO_LANGUAGE_ID: Readonly<Record<string, string | string[]>> = {
+  // JSON plugin
+  ".json": ["json", "jsonc"],
+  ".jsonc": "jsonc",
+  // TypeScript / JavaScript
+  ".ts": "typescript",
+  ".tsx": "typescriptreact",
+  ".js": "javascript",
+  ".jsx": "javascriptreact",
+  ".mts": "typescript",
+  ".cts": "typescript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  // Markdown
+  ".md": "markdown",
+  ".mdx": "markdown",
+  // TOML
+  ".toml": "toml",
+  // Dockerfile
+  "dockerfile": "dockerfile",
+  // Malva (CSS/SCSS/Sass/Less)
+  ".css": "css",
+  ".scss": "scss",
+  ".sass": "sass",
+  ".less": "less",
+  // Pretty GraphQL
+  ".graphql": "graphql",
+  ".gql": "graphql",
+  // Pretty YAML
+  ".yaml": "yaml",
+  ".yml": "yaml",
+  // Markup_fmt (HTML and templating)
+  ".html": "html",
+  ".vue": "vue",
+  ".svelte": "svelte",
+  ".astro": "astro",
+  ".jinja": "jinja",
+  ".jinja2": "jinja",
+  ".twig": "twig",
+  ".njk": "nunjucks",
+  ".vento": "vento",
+  // Ruff (Python)
+  ".py": "python",
+  ".pyi": "python",
+  // Jupyter
+  ".ipynb": "jupyter",
+  // PHP (Mago)
+  ".php": "php",
+  // C# / VB (Roslyn process plugin)
+  ".cs": "csharp",
+  ".vb": "vb",
+  // Code-workspace (VS Code uses jsonc)
+  ".code-workspace": "jsonc",
+};
+
+/**
+ * Returns the set of VS Code language IDs that the given plugins support,
+ * so the extension can register document formatter selectors only for those languages.
+ */
+export function getSupportedLanguageIds(plugins: ReadonlyArray<PluginInfo>): string[] {
+  const ids = new Set<string>();
+  for (const plugin of plugins) {
+    for (const ext of plugin.fileExtensions) {
+      const normalized = ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`;
+      const mapped = EXTENSION_AND_FILENAME_TO_LANGUAGE_ID[normalized];
+      if (mapped != null) {
+        if (typeof mapped === "string") {
+          ids.add(mapped);
+        } else {
+          for (const id of mapped) {
+            ids.add(id);
+          }
+        }
+      }
+    }
+    for (const name of plugin.fileNames) {
+      const normalized = name.toLowerCase();
+      const mapped = EXTENSION_AND_FILENAME_TO_LANGUAGE_ID[normalized];
+      if (mapped != null) {
+        if (typeof mapped === "string") {
+          ids.add(mapped);
+        } else {
+          for (const id of mapped) {
+            ids.add(id);
+          }
+        }
+      }
+    }
+  }
+  return [...ids];
+}
+
+/** Language IDs that some dprint plugin can format (for "offer to add plugin" suggestions). */
+export const ALL_DPRINT_SUPPORTABLE_LANGUAGE_IDS = new Set<string>(
+  Object.values(EXTENSION_AND_FILENAME_TO_LANGUAGE_ID).flatMap(m => (typeof m === "string" ? [m] : m)),
+);
+
+/** Plugin suggestion when user has no plugin for a supportable language. */
+export interface PluginSuggestion {
+  name: string;
+  helpUrl: string;
+  /** Exact plugin URL to add to dprint config (for one-click install). */
+  pluginUrl: string;
+}
+
+/** Map of VS Code language ID to suggested dprint plugin (name, docs URL, plugin URL). */
+export const LANGUAGE_ID_TO_PLUGIN_SUGGESTION: Readonly<Record<string, PluginSuggestion>> = {
+  json: { name: "JSON", helpUrl: "https://dprint.dev/plugins/json", pluginUrl: "https://plugins.dprint.dev/json-0.21.1.wasm" },
+  jsonc: { name: "JSON", helpUrl: "https://dprint.dev/plugins/json", pluginUrl: "https://plugins.dprint.dev/json-0.21.1.wasm" },
+  typescript: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
+  typescriptreact: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
+  javascript: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
+  javascriptreact: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
+  markdown: { name: "Markdown", helpUrl: "https://dprint.dev/plugins/markdown", pluginUrl: "https://plugins.dprint.dev/markdown-0.20.0.wasm" },
+  toml: { name: "TOML", helpUrl: "https://dprint.dev/plugins/toml", pluginUrl: "https://plugins.dprint.dev/toml-0.7.0.wasm" },
+  dockerfile: { name: "Dockerfile", helpUrl: "https://dprint.dev/plugins/dockerfile", pluginUrl: "https://plugins.dprint.dev/dockerfile-0.3.3.wasm" },
+  css: { name: "Malva (CSS/SCSS/Sass/Less)", helpUrl: "https://dprint.dev/plugins/malva", pluginUrl: "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm" },
+  scss: { name: "Malva (CSS/SCSS/Sass/Less)", helpUrl: "https://dprint.dev/plugins/malva", pluginUrl: "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm" },
+  sass: { name: "Malva (CSS/SCSS/Sass/Less)", helpUrl: "https://dprint.dev/plugins/malva", pluginUrl: "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm" },
+  less: { name: "Malva (CSS/SCSS/Sass/Less)", helpUrl: "https://dprint.dev/plugins/malva", pluginUrl: "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm" },
+  graphql: { name: "Pretty GraphQL", helpUrl: "https://dprint.dev/plugins/pretty_graphql", pluginUrl: "https://plugins.dprint.dev/pretty_graphql-0.0.0.wasm" },
+  yaml: { name: "Pretty YAML", helpUrl: "https://dprint.dev/plugins/pretty_yaml", pluginUrl: "https://plugins.dprint.dev/pretty_yaml-0.0.0.wasm" },
+  html: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  vue: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  svelte: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  python: { name: "Ruff (Python)", helpUrl: "https://dprint.dev/plugins/ruff", pluginUrl: "https://plugins.dprint.dev/ruff-0.0.0.wasm" },
+  php: { name: "Mago (PHP)", helpUrl: "https://dprint.dev/plugins/mago", pluginUrl: "https://plugins.dprint.dev/mago-0.0.0.wasm" },
+  csharp: { name: "Roslyn (C#/VB)", helpUrl: "https://dprint.dev/plugins/roslyn", pluginUrl: "https://plugins.dprint.dev/roslyn" },
+  vb: { name: "Roslyn (C#/VB)", helpUrl: "https://dprint.dev/plugins/roslyn", pluginUrl: "https://plugins.dprint.dev/roslyn" },
+  astro: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  jinja: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  twig: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  nunjucks: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  vento: { name: "Markup_fmt", helpUrl: "https://dprint.dev/plugins/markup_fmt", pluginUrl: "https://plugins.dprint.dev/markup_fmt-0.0.0.wasm" },
+  jupyter: { name: "Jupyter", helpUrl: "https://dprint.dev/plugins/jupyter", pluginUrl: "https://plugins.dprint.dev/jupyter-0.0.0.wasm" },
+  mdx: { name: "Markdown", helpUrl: "https://dprint.dev/plugins/markdown", pluginUrl: "https://plugins.dprint.dev/markdown-0.20.0.wasm" },
+};
+
+/** Barebones dprint.jsonc with commented plugin lines; uncomment to enable. */
+export const BAREBOONES_DPRINT_JSONC = `{
+  "indentWidth": 2,
+  "lineWidth": 120,
+  "excludes": [
+    "**/node_modules",
+    "**/*-lock.json",
+    "**/dist",
+    "**/.git"
+  ],
+  "plugins": [
+    // TypeScript / JavaScript
+    // "https://plugins.dprint.dev/typescript-0.95.15.wasm",
+    // JSON
+    // "https://plugins.dprint.dev/json-0.21.1.wasm",
+    // Markdown
+    // "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+    // TOML
+    // "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    // Dockerfile
+    // "https://plugins.dprint.dev/dockerfile-0.3.3.wasm",
+    // CSS/SCSS/Sass/Less (Malva)
+    // "https://plugins.dprint.dev/g-plane/malva-v0.15.2.wasm",
+    // YAML (run: dprint config add g-plane/pretty_yaml)
+    // "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.2.0.wasm",
+    // GraphQL (run: dprint config add g-plane/pretty_graphql)
+    // "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.0.wasm",
+    // HTML/Vue/Svelte/Astro etc (run: dprint config add g-plane/markup_fmt)
+    // "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm",
+    // Python (run: dprint config add ruff)
+    // "https://plugins.dprint.dev/ruff-0.1.0.wasm"
+  ]
+}
+`;

--- a/src/legacy/supportedLanguages.ts
+++ b/src/legacy/supportedLanguages.ts
@@ -60,8 +60,8 @@ const EXTENSION_AND_FILENAME_TO_LANGUAGE_ID: Readonly<Record<string, string | st
   // C# / VB (Roslyn process plugin)
   ".cs": "csharp",
   ".vb": "vb",
-  // Code-workspace (VS Code uses jsonc)
-  ".code-workspace": "jsonc",
+  // Code-workspace (VS Code language ID is "code-workspace"; same plugin as jsonc)
+  ".code-workspace": ["jsonc", "code-workspace"],
 };
 
 /**
@@ -98,6 +98,10 @@ export function getSupportedLanguageIds(plugins: ReadonlyArray<PluginInfo>): str
       }
     }
   }
+  // VS Code uses language id "code-workspace" for .code-workspace files; same plugin as jsonc
+  if (ids.has("jsonc")) {
+    ids.add("code-workspace");
+  }
   return [...ids];
 }
 
@@ -118,6 +122,7 @@ export interface PluginSuggestion {
 export const LANGUAGE_ID_TO_PLUGIN_SUGGESTION: Readonly<Record<string, PluginSuggestion>> = {
   json: { name: "JSON", helpUrl: "https://dprint.dev/plugins/json", pluginUrl: "https://plugins.dprint.dev/json-0.21.1.wasm" },
   jsonc: { name: "JSON", helpUrl: "https://dprint.dev/plugins/json", pluginUrl: "https://plugins.dprint.dev/json-0.21.1.wasm" },
+  "code-workspace": { name: "JSON", helpUrl: "https://dprint.dev/plugins/json", pluginUrl: "https://plugins.dprint.dev/json-0.21.1.wasm" },
   typescript: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
   typescriptreact: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },
   javascript: { name: "TypeScript", helpUrl: "https://dprint.dev/plugins/typescript", pluginUrl: "https://plugins.dprint.dev/typescript-0.95.15.wasm" },


### PR DESCRIPTION
Fixes #138

**Original fix:** VS Code does not reliably associate the extension with jsonc (and json) when the formatter is registered only via glob patterns. We explicitly register `DocumentFormattingEditProvider` for language IDs so dprint appears in the default formatter list for those languages.

**Expanded scope in this PR:**

1. **Register only for languages that have a plugin**  
   We derive supported language IDs from the plugins reported by `dprint editor-info` (using each plugin’s `fileExtensions` / `fileNames`). We only add explicit document selectors for those languages, so we don’t claim jsonc/json (or yaml, graphql, etc.) unless that plugin is in the config.

2. **One-click “Add to config”**  
   When we suggest adding a plugin (e.g. “dprint could format this file with the JSON plugin”), we offer **“Add to config”** in addition to “Open plugin docs”. Clicking it finds or creates a dprint config file, then either uncomments an existing commented plugin line (if present) or appends the plugin URL to the `plugins` array, and opens the file.

3. **Offer to create dprint.jsonc when dprint is set but no config**  
   If the user has dprint as default formatter (workspace or user settings) but no dprint config exists in the workspace, we offer to create a starter `dprint.jsonc` at the workspace root with commented common plugin lines, then open it so they can uncomment what they need.

4. **Uncomment when installing a plugin**  
   When adding a plugin via one-click, we first look for a commented line in the config that matches that plugin (by URL or slug); if found, we uncomment it instead of appending a duplicate.

**New/updated files:** `supportedLanguages.ts` (plugin→language mapping + barebones template), `dprintConfigEditor.ts` (find/create config, add or uncomment plugin). Updated `context.ts` (use supported language IDs from plugins) and `WorkspaceService.ts` (suggestion UI, create-config offer, one-click handler).
